### PR TITLE
Remove pivot argument w/ default value in cholesky!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SparseRegression"
 uuid = "ca6142a6-a6a7-57f5-b674-4a8484b22e92"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 LearnBase = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 environment:
   matrix:
-  - julia_version: 1.0
-  - julia_version: 1.1
+  - julia_version: 1.2
+  - julia_version: 1.6
+  - julia_version: 1
   - julia_version: nightly
 
 platform:

--- a/src/algorithms/algorithms.jl
+++ b/src/algorithms/algorithms.jl
@@ -268,6 +268,6 @@ Base.show(io::IO, a::LinRegCholesky) = print(io, "LinRegCholesky")
 function update!(o::SModel, a::LinRegCholesky)
     copyto!(a.S, a.A)
     add_ridge!(o, a)
-    cholesky!(Symmetric(a.S), Val(false))
+    cholesky!(Symmetric(a.S))
     @views o.β[:] = UpperTriangular(a.S[1:end-1, 1:end-1]) \ a.S[1:end-1, end]
 end


### PR DESCRIPTION
Removing the explicit `Val(false)` avoids getting depwarns due to the upcoming https://github.com/JuliaLang/julia/pull/41640. Constant propagation (of the default value) should prevent any performance or type inference regression. This PR does not need to wait for the Julia PR to be merged. Another option would to be have a `VERSION`-dependent definition of `nopivot_cholesky!(A)` that expands to either `cholesky!(A, Val(false))` or `cholesky!(A, NoPivot())`.

I'm not sure though that this prevents the error in the pkg eval run https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/d6eba05_vs_63f5b8a/SparseRegression.1.8.0-DEV-96875a2ac12.log